### PR TITLE
modifying test_utils.jl to be exported as abstract_utils.jl

### DIFF
--- a/src/abstract_core.jl
+++ b/src/abstract_core.jl
@@ -6,14 +6,21 @@ abstract type AbstractExpression end
 
 # Define Algebraic Operators
 include("abstract_operations.jl")
+
 # Define Domains
 include("abstract_domains.jl")
+
 # Define Fields
 include("abstract_fields.jl")
+
 # Define Data
 include("abstract_data.jl")
+
 # Define equations and systems
 include("abstract_equations.jl")
+
+# Define Wrapper functions and derivative utils
+include("abstract_utils.jl")
 
 # compute function
 compute(a::AbstractExpression) = throw(error("compute not defined for $(typeof(a))"))

--- a/src/abstract_utils.jl
+++ b/src/abstract_utils.jl
@@ -1,7 +1,7 @@
 # Quick Structs for checking calculations
 import Impero:compute
 
-export Wrapper, WrapperMetaData, wrapper, show
+export Wrapper, WrapperMetaData, wrapper, @wrapper, show
 export DirectionalDerivative, GradientMetaData, ∂x, ∂y, ∂z, ∂t
 
 struct Wrapper{T, S} <: AbstractExpression

--- a/src/abstract_utils.jl
+++ b/src/abstract_utils.jl
@@ -1,0 +1,67 @@
+# Quick Structs for checking calculations
+import Impero:compute
+
+export Wrapper, WrapperMetaData, wrapper, show
+export DirectionalDerivative, GradientMetaData, ∂x, ∂y, ∂z, ∂t
+
+struct Wrapper{T, S} <: AbstractExpression
+    data::T
+    meta_data::S
+end
+# Struct for MetaData
+struct WrapperMetaData{T}
+    io_name::T
+end
+
+function Base.show(io::IO, field::Wrapper{T, S}) where {T <: Char, S}
+    color = 230
+    printstyled(io, field.data, color = color)
+end
+function Base.show(io::IO, field::Wrapper{T, S}) where {T, S <: WrapperMetaData}
+    color = 230
+    printstyled(io, field.meta_data.io_name, color = color)
+end
+
+compute(a::Wrapper) = a.data
+
+macro wrapper(expr)
+    rewritten_expr = _wrapper(expr)
+    return rewritten_expr
+end
+
+function _wrapper(expr::Expr)
+    symb = expr.args[1]
+    val  = expr.args[2]
+    string_symb = String(symb)
+    new_expr = :($(esc(symb)) =  Wrapper($val, WrapperMetaData($string_symb)))
+    return new_expr
+end
+
+macro wrapper(exprs...)
+    rewritten_exprs = [_wrapper(expr) for expr in exprs]
+    return Expr(:block, rewritten_exprs...)
+end
+
+## Add directional derivatives
+struct DirectionalDerivative{𝒮} <: AbstractExpression
+    direction::𝒮
+end
+struct GradientMetaData{𝒮}
+    direction::𝒮
+end
+function (p::DirectionalDerivative)(expr::AbstractExpression)
+    return Gradient(expr, GradientMetaData(p.direction))
+end
+function Base.show(io::IO, p::DirectionalDerivative{S}) where S <: String
+    print(io, Char(0x02202) * p.direction)
+end
+function Base.show(io::IO, p::Gradient{S, T}) where {S, T <: GradientMetaData{String}}
+    printstyled(io, Char(0x02202) * p.metadata.direction, "(", color = 165)
+    print(io, p.operand)
+    printstyled(io, ")", color = 165)
+end
+
+∂x = DirectionalDerivative("x")
+∂y = DirectionalDerivative("y")
+∂z = DirectionalDerivative("z")
+∂t = DirectionalDerivative("t")

--- a/test/equation_test.jl
+++ b/test/equation_test.jl
@@ -1,9 +1,6 @@
 using Impero, Test
 
-# define wrappers and derivatives
-include(pwd() * "/test/test_utils.jl")
-
-@wrapper u=1 σ=1
+Impero.@wrapper u=1 σ=1
 
 @testset "Impero Equation Specification" begin
     equ = @to_equation σ=u

--- a/test/equation_test.jl
+++ b/test/equation_test.jl
@@ -1,6 +1,6 @@
 using Impero, Test
 
-Impero.@wrapper u=1 σ=1
+@wrapper u=1 σ=1
 
 @testset "Impero Equation Specification" begin
     equ = @to_equation σ=u

--- a/test/preliminary_tests.jl
+++ b/test/preliminary_tests.jl
@@ -1,9 +1,7 @@
 using Impero
 using Test
 
-include(pwd() * "/test/test_utils.jl")
-
-@wrapper a=1 b=2 d=4
+Impero.@wrapper a=1 b=2 d=4
 
 @testset "Impero operator matching" begin
 

--- a/test/preliminary_tests.jl
+++ b/test/preliminary_tests.jl
@@ -1,7 +1,7 @@
 using Impero
 using Test
 
-Impero.@wrapper a=1 b=2 d=4
+@wrapper a=1 b=2 d=4
 
 @testset "Impero operator matching" begin
 

--- a/test/symbolic_utils_tests.jl
+++ b/test/symbolic_utils_tests.jl
@@ -4,7 +4,7 @@ using SymbolicUtils
 import SymbolicUtils: Chain, Postwalk
 import SymbolicUtils: Sym, Term, istree, operation, arguments, to_symbolic, Fixpoint
 
-Impero.@wrapper a=1 b=2
+@wrapper a=1 b=2
 
 @testset "symbolic utils swapping" begin
     println("for $a = ", a.data, ", $b = ", b.data)

--- a/test/symbolic_utils_tests.jl
+++ b/test/symbolic_utils_tests.jl
@@ -4,9 +4,7 @@ using SymbolicUtils
 import SymbolicUtils: Chain, Postwalk
 import SymbolicUtils: Sym, Term, istree, operation, arguments, to_symbolic, Fixpoint
 
-include(pwd() * "/test/test_utils.jl")
-
-@wrapper a=1 b=2
+Impero.@wrapper a=1 b=2
 
 @testset "symbolic utils swapping" begin
     println("for $a = ", a.data, ", $b = ", b.data)

--- a/test/to_expr_test.jl
+++ b/test/to_expr_test.jl
@@ -4,7 +4,6 @@ theme(:default)
 default(size=(500, 500))
 plot_flag = false
 
-include(pwd() * "/test/test_utils.jl")
 @wrapper α=1 β=1 ψ=1 ϕ=1
 
 @testset "Testing to_expr function" begin


### PR DESCRIPTION
This moves the core functionality of `test_utils.jl` into `abstract_utils.jl` and exports it as Impero native functionality.